### PR TITLE
Added keymaps for formatting and added toggling of fonts

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -72,7 +72,7 @@
             <button class="sansItalic" title="Italic">𝘐</button>
             <button class="monospace" title="Monospace">𝙼</button>
             <button title="Underline" data-append="͟" style="text-decoration: underline;">U</button>
-            <button class="sans" title="Strikethrough" data-append="̶" style="text-decoration: line-through;">S</button>
+            <button title="Strikethrough" data-append="̶" style="text-decoration: line-through;">S</button>
         </div>
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -59,7 +59,7 @@
     <div class="controls">
         <span class="fonts-label">Fonts:</span>
         <div class="control-btns">
-            <button class="normal" title="Normal">
+            <button class="normal" title="Normal" data-clear="true">
                 <!-- Eraser Icon -->
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 24 24"
                     xmlns="http://www.w3.org/2000/svg">

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,6 +35,8 @@ let formatter = {
       mode: null,
       lineWrapping: true
     });
+    // list of font characters for checking if character is formatted
+    this.allCharacters = new Set(Object.values(this.fonts).join(""));
     // add keymaps
     this.CodeMirror.setOption("extraKeys", {
       "Ctrl-B": () => this.formatSelections("sansBold"),
@@ -46,8 +48,32 @@ let formatter = {
     });
   },
 
+  // check if text is already formatted with a certain font
+  alreadyFormatted: function (text, font) {
+    const fontCharacters = new Set(this.fonts[font]);
+    // flag as already formatted if all characters are in font or not in any other font
+    return Array.from(text).every((char) =>
+      fontCharacters.has(char) || !this.allCharacters.has(char)
+    );
+  },
+
+  // check if text is already formatted with a certain font
+  alreadyAppended: function (text, append) {
+    // check if at least half the characters are the append character
+    return Array.from(text).filter((char) => char == append).length >= text.length / 2;
+  },
+
   // format text into selected font
   formatText: function (text, font, options) {
+    // set font to normal if already formatted with selected font
+    if (this.fonts[font] && this.alreadyFormatted(text, font)) {
+      font = "normal";
+    }
+    // remove and don't append if character is already appended
+    if (options?.append) {
+      options.remove = options.append;
+      options.append = !this.alreadyAppended(text, options.append) ? options.append : "";
+    }
     // Array.from() splits the string by symbol and not by code points
     let newText = Array.from(text);
     // exchange font symbols
@@ -69,6 +95,8 @@ let formatter = {
     }
     // reverse text if reverse option is set
     newText = options?.reverse ? newText.reverse() : newText;
+    // remove appended symbol of specific type from the end
+    newText = options?.remove ? newText.map((char) => char.replace(new RegExp(options.remove + "$", "u"), "")) : newText;
     // append symbol (underline, strikethrough, etc.) to end of each character if append is set
     newText = options?.append ? newText.map((char) => char + options.append) : newText;
     // remove appended symbols (underline, strikethrough, etc.) if using eraser
@@ -130,7 +158,7 @@ window.addEventListener("load", function () {
   document.querySelectorAll(".control-btns button").forEach(function (btn) {
     btn.addEventListener("click", function () {
       // format highlighted text into selected font
-      formatter.formatSelections(this.className, this.dataset);
+      formatter.formatSelections(this.className, {...this.dataset});
     }, false);
   });
 }, false);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -39,12 +39,29 @@ let formatter = {
     this.allCharacters = new Set(Object.values(this.fonts).join(""));
     // add keymaps
     this.CodeMirror.setOption("extraKeys", {
+      // Bold
       "Ctrl-B": () => this.formatSelections("sansBold"),
+      // Italic
       "Ctrl-I": () => this.formatSelections("sansItalic"),
+      // Monospace
+      "Ctrl-M": () => this.formatSelections("monospace"),
+      // Underline
       "Ctrl-U": () => this.formatSelections("", {
         append: "͟"
       }),
-      "Ctrl-M": () => this.formatSelections("monospace"),
+      // Strikethrough
+      "Alt-K": () => this.formatSelections("", {
+        append: "̶"
+      }),
+      "Shift-Alt-5": () => this.formatSelections("", {
+        append: "̶"
+      }),
+      // Superscript
+      "Shift-Ctrl-=": () => this.formatSelections("superscript"),
+      "Ctrl-.": () => this.formatSelections("superscript"),
+      // Subscript
+      "Ctrl-=": () => this.formatSelections("subscript"),
+      "Ctrl-,": () => this.formatSelections("superscript"),
     });
   },
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,6 +35,15 @@ let formatter = {
       mode: null,
       lineWrapping: true
     });
+    // add keymaps
+    this.CodeMirror.setOption("extraKeys", {
+      "Ctrl-B": () => this.formatSelections("sansBold"),
+      "Ctrl-I": () => this.formatSelections("sansItalic"),
+      "Ctrl-U": () => this.formatSelections("", {
+        append: "͟"
+      }),
+      "Ctrl-M": () => this.formatSelections("monospace"),
+    });
   },
 
   // format text into selected font

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -100,6 +100,7 @@ let formatter = {
     // append symbol (underline, strikethrough, etc.) to end of each character if append is set
     newText = options?.append ? newText.map((char) => char + options.append) : newText;
     // remove appended symbols (underline, strikethrough, etc.) if using eraser
+    // \u035f = Underline, \u0333 = Double Underline, \u0335 = Short Strikethrough \u0336 = Strikethrough
     newText = options?.clear ? newText.map((char) => char.replace(/\u035f|\u0333|\u0335|\u0336/gu, "")) : newText;
     // set textarea content and select text around the replacement
     return newText.join("");

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -72,7 +72,7 @@ let formatter = {
     // append symbol (underline, strikethrough, etc.) to end of each character if append is set
     newText = options?.append ? newText.map((char) => char + options.append) : newText;
     // remove appended symbols (underline, strikethrough, etc.) if using eraser
-    newText = font === "normal" ? newText.map((char) => char.replace(/\u035f|\u0333|\u0335|\u0336/gu, "")) : newText;
+    newText = options?.clear ? newText.map((char) => char.replace(/\u035f|\u0333|\u0335|\u0336/gu, "")) : newText;
     // set textarea content and select text around the replacement
     return newText.join("");
   },


### PR DESCRIPTION
Fixes #1

### Added Keymaps

Bold - <kbd>Ctrl</kbd> <kbd>B</kbd>

Italic - <kbd>Ctrl</kbd> <kbd>I</kbd>

Monospace - <kbd>Ctrl</kbd> <kbd>M</kbd>

Underline - <kbd>Ctrl</kbd> <kbd>U</kbd>

Strikethrough - <kbd>Alt</kbd> <kbd>K</kbd> or <kbd>Alt</kbd> <kbd>Shift</kbd> <kbd>5</kbd>

Superscript - <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>+</kbd> or <kbd>Ctrl</kbd> <kbd>.</kbd>

Subscript - <kbd>Ctrl</kbd> <kbd>=</kbd> or <kbd>Ctrl</kbd> <kbd>,</kbd>
